### PR TITLE
Add read/write_register and lemmas

### DIFF
--- a/src/MicroSail/Context.v
+++ b/src/MicroSail/Context.v
@@ -130,6 +130,8 @@ Module CtxNotations.
   Notation "Γ1 ▻▻ Γ2" := (ctx_cat Γ1 Γ2) : ctx_scope.
   Notation "b ∈ Γ" := (InCtx b Γ) : type_scope.
 
+  (* NB: ∶ ≠ :
+     To typeset the next notation, use \: *)
   Notation "x ∶ τ" := (pair x τ) : ctx_scope.
   Notation "[ x ]" := (ctx_snoc ctx_nil x)  : ctx_scope.
   Notation "[ x , .. , z ]" := (ctx_snoc .. (ctx_snoc ctx_nil x) .. z) : ctx_scope.

--- a/src/MicroSail/SmallStep/Step.v
+++ b/src/MicroSail/SmallStep/Step.v
@@ -170,7 +170,7 @@ Module SmallStep
 
   | step_stm_reg_register
       (γ : RegStore) (δ : LocalStore Γ) {σ : Ty} (r : 𝑹𝑬𝑮 σ) :
-      ⟨ γ, δ, stm_read_register r ⟩ ---> ⟨ γ, δ, stm_lit σ (γ σ r) ⟩
+      ⟨ γ, δ, stm_read_register r ⟩ ---> ⟨ γ, δ, stm_lit σ (read_register γ r) ⟩
   | step_stm_write_register
       (γ : RegStore) (δ : LocalStore Γ) {σ : Ty} (r : 𝑹𝑬𝑮 σ) (e : Exp Γ σ) :
       let v := eval e δ in

--- a/src/MicroSail/Syntax.v
+++ b/src/MicroSail/Syntax.v
@@ -258,7 +258,7 @@ Module Type TermKit (typekit : TypeKit).
 
   (* Names of registers. *)
   Parameter Inline 𝑹𝑬𝑮 : Ty -> Set.
-  Parameter Inline 𝑹𝑬𝑮_eq_dec : forall σ (r1 r2 : 𝑹𝑬𝑮 σ), {r1 = r2} + {r1 <> r2}.
+  (* Parameter Inline 𝑹𝑬𝑮_eq_dec : forall σ (r1 r2 : 𝑹𝑬𝑮 σ), {r1 = r2} + {r1 <> r2}. *)
 
 End TermKit.
 

--- a/src/MicroSail/Syntax.v
+++ b/src/MicroSail/Syntax.v
@@ -827,6 +827,15 @@ Module Type ProgramKit
   Parameter read_register : forall (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ), Lit σ.
   Parameter write_register : forall (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) (v : Lit σ), RegStore.
 
+  Parameter read_write : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v : Lit σ),
+            read_register (write_register γ r v) r = v.
+
+  Parameter write_read : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ),
+            (write_register γ r (read_register γ r)) = γ.
+
+  Parameter write_write : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v1 v2 : Lit σ),
+            write_register (write_register γ r v1) r v2 = write_register γ r v2.
+
   (* Parameter Inline Pi : forall {Δ τ} (f : 𝑭 Δ τ), FunDef Δ τ. *)
   Parameter Inline Pi : forall {Δ τ} (f : 𝑭 Δ τ), Stm Δ τ.
 

--- a/src/MicroSail/Syntax.v
+++ b/src/MicroSail/Syntax.v
@@ -258,6 +258,7 @@ Module Type TermKit (typekit : TypeKit).
 
   (* Names of registers. *)
   Parameter Inline 𝑹𝑬𝑮 : Ty -> Set.
+  Parameter Inline 𝑹𝑬𝑮_eq_dec : forall σ (r1 r2 : 𝑹𝑬𝑮 σ), {r1 = r2} + {r1 <> r2}.
 
 End TermKit.
 
@@ -396,12 +397,6 @@ Module Terms (typekit : TypeKit) (termkit : TermKit typekit).
 
   Definition LocalStore (Γ : Ctx (𝑿 * Ty)) : Type := Env' Lit Γ.
   Bind Scope env_scope with LocalStore.
-
-  Definition RegStore : Type := forall σ, 𝑹𝑬𝑮 σ -> Lit σ.
-  Bind Scope env_scope with RegStore.
-
-  Definition write_register (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) (v : Lit σ) : RegStore.
-  Admitted.
 
   Section Expressions.
 
@@ -822,6 +817,15 @@ Module Type ProgramKit
        (Import termkit : TermKit typekit).
   Module TM := Terms typekit termkit.
   Export TM.
+
+  (* We choose to make [RegStore] a parameter so the users of the module would be able to
+     instantiate it with their own data structure and [read_regsiter]/[write_register]
+     functions *)
+  Parameter RegStore : Type.
+  (* Definition RegStore : Type := forall σ, 𝑹𝑬𝑮 σ -> Lit σ. *)
+  Bind Scope env_scope with RegStore.
+  Parameter read_register : forall (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ), Lit σ.
+  Parameter write_register : forall (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) (v : Lit σ), RegStore.
 
   (* Parameter Inline Pi : forall {Δ τ} (f : 𝑭 Δ τ), FunDef Δ τ. *)
   Parameter Inline Pi : forall {Δ τ} (f : 𝑭 Δ τ), Stm Δ τ.

--- a/test/Example.v
+++ b/test/Example.v
@@ -204,6 +204,18 @@ Module ExampleProgramKit <: (ProgramKit ExampleTypeKit ExampleTermKit).
     end in exact pi.
   Defined.
 
+Definition RegStore := Empty_set.
+Definition read_register (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) : Lit σ :=
+  match r with end.
+Definition write_register (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) (v : Lit σ) : RegStore :=
+  match r with end.
+Definition read_write (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v : Lit σ) :
+    read_register (write_register γ r v) r = v := match r with end.
+Definition write_read (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) :
+    (write_register γ r (read_register γ r)) = γ := match r with end.
+Definition write_write (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v1 v2 : Lit σ) :
+    write_register (write_register γ r v1) r v2 = write_register γ r v2 :=
+  match r with end.
 End ExampleProgramKit.
 Module ExamplePrograms :=
   Programs ExampleTypeKit ExampleTermKit ExampleProgramKit.

--- a/test/ISA.v
+++ b/test/ISA.v
@@ -21,12 +21,10 @@ Open Scope string_scope.
 Open Scope Z_scope.
 Open Scope ctx_scope.
 
-Inductive Unions := instruction.
+Inductive Unions : Set := instruction.
 
 Lemma Unions_eq_dec : EqDec Unions.
   unfold EqDec.
-  intros x y.
-  destruct x. destruct y.
   decide equality.
 Qed.
 
@@ -158,13 +156,6 @@ Module ExampleProgramKit <: (ProgramKit ExampleTypeKit ExampleTermKit).
     intros γ σ r v. now destruct r.
   Qed.
 
-  Lemma write_read_pw : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ),
-      (write_register γ r (read_register γ r)) σ r = γ σ r.
-  Proof.
-    intros γ σ r.
-    now destruct r.
-  Qed.
-
   Lemma write_read : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ),
       (write_register γ r (read_register γ r)) = γ.
   Proof.
@@ -174,14 +165,14 @@ Module ExampleProgramKit <: (ProgramKit ExampleTypeKit ExampleTermKit).
     extensionality r'.
     destruct r';
     destruct r;
-    destruct γ; now simp write_register.
+    now simp write_register.
   Qed.
 
   Lemma write_write : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v1 v2 : Lit σ),
             write_register (write_register γ r v1) r v2 = write_register γ r v2.
   Proof.
-    intros γ σ r v1 v2;
-    destruct r; destruct v2; trivial.
+    intros γ σ r v1 v2.
+    now destruct r.
   Qed.
 
   Local Coercion stm_exp : Exp >-> Stm.

--- a/test/ISA.v
+++ b/test/ISA.v
@@ -4,7 +4,8 @@ From Coq Require Import
      Program.Tactics
      Strings.String
      ZArith.ZArith
-     micromega.Lia.
+     micromega.Lia
+     Logic.FunctionalExtensionality.
 
 From Equations Require Import
      Equations.
@@ -156,6 +157,38 @@ Module ExampleProgramKit <: (ProgramKit ExampleTypeKit ExampleTermKit).
     write_register γ R2 v R2 := v;
     write_register γ R3 v R3 := v;
     write_register γ r1 v r2 := γ _ r2.
+
+  Lemma read_write : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v : Lit σ),
+      read_register (write_register γ r v) r = v.
+  Proof.
+    intros γ σ r v. now destruct r.
+  Qed.
+
+  Lemma write_read_pw : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ),
+      (write_register γ r (read_register γ r)) σ r = γ σ r.
+  Proof.
+    intros γ σ r.
+    now destruct r.
+  Qed.
+
+  Lemma write_read : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ),
+      (write_register γ r (read_register γ r)) = γ.
+  Proof.
+    intros γ σ r.
+    unfold read_register.
+    extensionality σ'.
+    extensionality r'.
+    destruct r';
+    destruct r;
+    destruct γ; now simp write_register.
+  Qed.
+
+  Lemma write_write : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v1 v2 : Lit σ),
+            write_register (write_register γ r v1) r v2 = write_register γ r v2.
+  Proof.
+    intros γ σ r v1 v2;
+    destruct r; destruct v2; trivial.
+  Qed.
 
   Local Coercion stm_exp : Exp >-> Stm.
   Local Open Scope exp_scope.

--- a/test/ISA.v
+++ b/test/ISA.v
@@ -128,13 +128,7 @@ Module ExampleTermKit <: (TermKit ExampleTypeKit).
     | R3 : Reg ty_int
     .
   Definition 𝑹𝑬𝑮 := Reg.
-  Definition 𝑹𝑬𝑮_eq_dec : forall σ, EqDec (𝑹𝑬𝑮 σ).
-  Proof.
-    unfold EqDec.
-    dependent destruction x;
-    dependent destruction y;
-    (now right) || (now left).
-  Defined.
+
 End ExampleTermKit.
 Module ExampleTerms := Terms ExampleTypeKit ExampleTermKit.
 Import ExampleTerms.

--- a/test/ISA.v
+++ b/test/ISA.v
@@ -1,0 +1,198 @@
+From Coq Require Import
+     Logic.FinFun
+     Program.Equality
+     Program.Tactics
+     Strings.String
+     ZArith.ZArith
+     micromega.Lia.
+
+From Equations Require Import
+     Equations.
+
+From MicroSail Require Import
+     WLP.Spec
+     Syntax.
+
+Set Implicit Arguments.
+Import CtxNotations.
+Import EnvNotations.
+Open Scope string_scope.
+Open Scope Z_scope.
+Open Scope ctx_scope.
+
+Inductive Unions := instruction.
+
+Lemma Unions_eq_dec : EqDec Unions.
+  unfold EqDec.
+  intros x y.
+  destruct x. destruct y.
+  decide equality.
+Qed.
+
+Inductive Instruction :=
+    Halt
+  | Load
+  | Add
+  | Jump
+  .
+
+(** Describe a part of REDFIN ISA
+    Property to verify:
+      Every instruction is memory safe, i.e. it checks memory
+      access and sets the 'OutOfMemory' flag if out of memory
+      access has been attempted. *)
+Module ExampleTypeKit <: TypeKit.
+
+  Definition 𝑬        := Empty_set.
+  Definition 𝑼        := Unions.
+  Definition 𝑹        := Empty_set.
+  Definition 𝑿        := string.
+
+  Definition 𝑬_eq_dec : EqDec 𝑬 := ltac:(unfold EqDec; decide equality).
+  Definition 𝑼_eq_dec : EqDec 𝑼 := Unions_eq_dec.
+  Definition 𝑹_eq_dec : EqDec 𝑹 := ltac:(unfold EqDec; decide equality).
+  Definition 𝑿_eq_dec : EqDec 𝑿 := string_dec.
+
+End ExampleTypeKit.
+Module ExampleTypes := Types ExampleTypeKit.
+Import ExampleTypes.
+
+Module ExampleTermKit <: (TermKit ExampleTypeKit).
+  Module TY := ExampleTypes.
+  Open Scope lit_scope.
+  (** ENUMS **)
+
+  Definition 𝑬𝑲 (E : 𝑬) : Set := Empty_set.
+  Program Instance Blastable_𝑬𝑲 E : Blastable (𝑬𝑲 E) :=
+    match E with end.
+
+  (** UNIONS **)
+  Definition 𝑼𝑲 (U : 𝑼) : Set :=
+    match U with
+    | instruction => Instruction
+    end.
+  Definition 𝑼𝑲_Ty (U : 𝑼) : 𝑼𝑲 U -> Ty :=
+    match U with
+    | instruction => fun K => match K with
+                          | Halt => ty_unit
+                          (* Load has two fields: register label and memory address *)
+                          (* represented as ints *)
+                          | Load => ty_prod ty_int ty_int
+                          | Add => ty_prod ty_int ty_int
+                          | Jump => ty_int
+                          end
+    end.
+  Program Instance Blastable_𝑼𝑲 U : Blastable (𝑼𝑲 U) :=
+    match U with
+    | instruction => {| blast v POST :=
+                     (v = Halt  -> POST Halt) /\
+                     (v = Load -> POST Load)  /\
+                     (v = Add -> POST Add)    /\
+                     (v = Jump -> POST Jump)
+                |}
+    end.
+  Solve All Obligations with destruct a; intuition congruence.
+
+  (** RECORDS **)
+  Definition 𝑹𝑭  : Set := Empty_set.
+  Definition 𝑹𝑭_Ty (R : 𝑹) : Ctx (𝑹𝑭 * Ty) := match R with end.
+
+  (** FUNCTIONS **)
+  (* Inductive Fun : Ctx (𝑿 * Ty) -> Ty -> Set := *)
+  (* | abs :     Fun [ "x" ∶ ty_int               ] ty_int *)
+  (* | cmp :     Fun [ "x" ∶ ty_int, "y" ∶ ty_int ] ty_int *)
+  (* | gcd :     Fun [ "x" ∶ ty_int, "y" ∶ ty_int ] ty_int *)
+  (* | gcdloop : Fun [ "x" ∶ ty_int, "y" ∶ ty_int ] ty_int *)
+  (* | msum :    Fun [ "x" ∶ ty_int , "y" ∶ ty_int ] ty_int *)
+  (* . *)
+
+  Inductive Fun : Ctx (𝑿 * Ty) -> Ty -> Set :=
+  | semantics : Fun [ "x" ∶ ty_union instruction] ty_unit
+  | ihalt : Fun ε ty_unit
+  | iload : Fun [ "dest_reg" ∶ ty_int , "src_addr" ∶ ty_int ] ty_unit
+  | iadd  : Fun [ "dest_reg" ∶ ty_int , "src_addr" ∶ ty_int ] ty_unit
+  | ijump : Fun [ "offset" ∶ ty_int ] ty_unit
+  .
+
+  Definition 𝑭 := Fun.
+
+  Inductive Reg : Ty -> Set :=
+      Halted      : Reg ty_bool
+    | Overflow    : Reg ty_bool
+    | OutOfMemory : Reg ty_bool
+
+    | R0 : Reg ty_int
+    | R1 : Reg ty_int
+    | R2 : Reg ty_int
+    | R3 : Reg ty_int
+    .
+  Definition 𝑹𝑬𝑮 := Reg.
+  Definition 𝑹𝑬𝑮_eq_dec : forall σ, EqDec (𝑹𝑬𝑮 σ).
+  Proof.
+    unfold EqDec.
+    dependent destruction x;
+    dependent destruction y;
+    (now right) || (now left).
+  Defined.
+End ExampleTermKit.
+Module ExampleTerms := Terms ExampleTypeKit ExampleTermKit.
+Import ExampleTerms.
+Import NameResolution.
+
+Module ExampleProgramKit <: (ProgramKit ExampleTypeKit ExampleTermKit).
+  Module TM := ExampleTerms.
+
+  Definition RegStore := forall σ, 𝑹𝑬𝑮 σ -> Lit σ.
+
+  Definition read_register (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) : Lit σ :=
+    γ σ r.
+
+  Equations write_register (γ : RegStore) {σ : Ty} (r : 𝑹𝑬𝑮 σ) (v : Lit σ) : RegStore :=
+    write_register γ Halted      v Halted      := v;
+    write_register γ OutOfMemory v OutOfMemory := v;
+    write_register γ Overflow    v Overflow    := v;
+    write_register γ R0 v R0 := v;
+    write_register γ R1 v R1 := v;
+    write_register γ R2 v R2 := v;
+    write_register γ R3 v R3 := v;
+    write_register γ r1 v r2 := γ _ r2.
+
+  Local Coercion stm_exp : Exp >-> Stm.
+  Local Open Scope exp_scope.
+  Local Open Scope stm_scope.
+
+  Local Notation "'x'"   := (@exp_var _ "x" _ _).
+  Local Notation "'y'"   := (@exp_var _ "y" _ _).
+  Local Notation "'z'"   := (@exp_var _ "z" _ _).
+
+  Local Notation "'load_args'"   := (exp_pair _ _).
+  Local Notation "'y'"   := (@exp_var _ "y" _ _).
+  Local Notation "'z'"   := (@exp_var _ "z" _ _).
+
+  Definition Pi {Δ τ} (f : Fun Δ τ) : Stm Δ τ.
+    let pi := eval compute in
+    match f in Fun Δ τ return Stm Δ τ with
+    | semantics => (@stm_match_union _ instruction x _
+        (fun K => match K with
+               | Halt => ""
+               | Load => "load_args"
+               | Add => "add_args"
+               | Jump => "jump_args"
+               end)
+        (fun K => match K return Stm _ _ with
+               | Halt => stm_fail _ "not implemented"
+               | Load => stm_match_pair (exp_var "load_args") "dest" "source"
+                                       (stm_fail _ "not implemented")
+               | Add => stm_fail _ "not implemented"
+               | Jump => stm_fail _ "not implemented"
+               (* | alt2%exp => rhs2%stm *)
+               end))
+    | ihalt => stm_fail _ "not implemented"
+    | iload => stm_fail _ "not implemented"
+    | iadd => stm_fail _ "not implemented"
+    | ijump => stm_fail _ "not implemented"
+    end in exact pi.
+  Defined.
+
+End ExampleProgramKit.
+Import ExampleProgramKit.


### PR DESCRIPTION
PR summary:

* `RegStore` is now a parameter of the `ProgramKit` module
* so are `read_register` and `write_register` functions and their associated lemmas
* `test/ISA.v` contains an example of instantiating `RegStore`, `read`/`write_register` and the lemmas.