### PR TITLE
Memory and registers

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -13,3 +13,4 @@ src/MicroSail/Tactics.v
 src/MicroSail/WLP/Soundness.v
 src/MicroSail/WLP/Spec.v
 test/Example.v
+test/ISA.v

--- a/src/MicroSail/Notation.v
+++ b/src/MicroSail/Notation.v
@@ -59,8 +59,8 @@ Reserved Notation "δ1 ►► δ2"       (at level 50, left associativity).
 Reserved Notation "δ ⟪ x ↦ v ⟫"    (at level 90, x at level 0, v at level 0, left associativity).
 Reserved Notation "δ ! x"          (at level 56, no associativity).
 
-Reserved Notation "⟨ γ1 , δ1 , s1 ⟩ ---> ⟨ γ2 , δ2 , s2 ⟩" (at level 75, no associativity).
-Reserved Notation "⟨ γ1 , δ1 , s1 ⟩ --->* ⟨ γ2 , δ2 , s2 ⟩" (at level 75, no associativity).
+Reserved Notation "⟨ γ1 , μ1 , δ1 , s1 ⟩ ---> ⟨ γ2 , μ2 , δ2 , s2 ⟩" (at level 75, no associativity).
+Reserved Notation "⟨ γ1 , μ1 , δ1 , s1 ⟩ --->* ⟨ γ2 , μ2 , δ2 , s2 ⟩" (at level 75, no associativity).
 (* Notation "( x , y , .. , z )" := *)
 (*   (tuplepat_snoc .. (tuplepat_snoc (tuplepat_snoc tuplepat_nil x) y) .. z) : pat_scope. *)
 

--- a/src/MicroSail/SmallStep/Inversion.v
+++ b/src/MicroSail/SmallStep/Inversion.v
@@ -66,8 +66,8 @@ Module Inversion
         => specialize (H _ _ _ eq_refl)
       | [ H : Final ?s -> _, H' : Final ?s |- _ ]
         => specialize (H H')
-      | [ H1 : ⟨ _, _, _ ⟩ ---> ⟨ ?γ2, ?δ2, ?s2 ⟩,
-          H2 : ⟨ ?γ2, ?δ2, ?s2 ⟩ --->* ⟨ _, _, _ ⟩ |- _ ]
+      | [ H1 : ⟨ _, _, _, _ ⟩ ---> ⟨ ?γ2, ?μ2, ?δ2, ?s2 ⟩,
+          H2 : ⟨ ?γ2, ?μ2, ?δ2, ?s2 ⟩ --->* ⟨ _, _, _, _ ⟩ |- _ ]
         => let H:=fresh in add_hypothesis H (step_trans H1 H2)
       | _ => progress steps_inversion_simpl
       end.
@@ -78,95 +78,96 @@ Module Inversion
       | [ |- exists t, _ ] => eexists
       | [ |- _ /\ _ ] => constructor
       | [ |- True ] => constructor
-      | [ |- ⟨ _, _, stm_lit _ _ ⟩ --->* ⟨ _, _, _ ⟩ ] => constructor 1
-      | [ |- ⟨ _, _, stm_fail _ _ ⟩ --->* ⟨ _, _, _ ⟩ ] => constructor 1
-      | [ |- ⟨ _, _, stm_let _ _ (stm_lit _ _) _ ⟩ ---> ⟨ _, _, _ ⟩ ] => apply step_stm_let_value
-      | [ |- ⟨ _, _, stm_let _ _ (stm_fail _ _) _ ⟩ ---> ⟨ _, _, _ ⟩ ] => apply step_stm_let_fail
-      | [ |- ⟨ _, _, stm_assign _ (stm_lit _ _) _ ⟩ ---> ⟨ _, _, _ ⟩ ] => apply step_stm_assign_value
-      | [ |- ⟨ _, _, stm_assign _ (stm_fail _ _) _ ⟩ ---> ⟨ _, _, _ ⟩ ] => apply step_stm_assign_fail
+      | [ |- ⟨ _, _, _, stm_lit _ _ ⟩ --->* ⟨ _, _, _, _ ⟩ ] => constructor 1
+      | [ |- ⟨ _, _, _, stm_fail _ _ ⟩ --->* ⟨ _, _, _, _ ⟩ ] => constructor 1
+      | [ |- ⟨ _, _, _, stm_let _ _ (stm_lit _ _) _ ⟩ ---> ⟨ _, _, _, _ ⟩ ] => apply step_stm_let_value
+      | [ |- ⟨ _, _, _, stm_let _ _ (stm_fail _ _) _ ⟩ ---> ⟨ _, _, _, _ ⟩ ] => apply step_stm_let_fail
+      | [ |- ⟨ _, _, _, stm_assign _ (stm_lit _ _) _ ⟩ ---> ⟨ _, _, _, _ ⟩ ] => apply step_stm_assign_value
+      | [ |- ⟨ _, _, _, stm_assign _ (stm_fail _ _) _ ⟩ ---> ⟨ _, _, _, _ ⟩ ] => apply step_stm_assign_fail
       | _ => progress cbn
       end; try eassumption.
 
   Local Ltac steps_inversion_induction :=
     let step := fresh in
-    induction 1 as [|? ? ? ? ? ? ? ? ? step]; intros; subst;
+    induction 1 as [|? ? ? ? ? ? ? ? ? ? ? ? step]; intros; subst;
       [ cbn in *; contradiction
       | inversion step; steps_inversion_inster; steps_inversion_solve
       ].
 
-  Lemma steps_inversion_let {Γ x τ σ} {γ1 γ3 : RegStore} {δ1 δ3 : LocalStore Γ}
+  Lemma steps_inversion_let {Γ x τ σ} {γ1 γ3 : RegStore} {μ1 μ3 : Memory}
+    {δ1 δ3 : LocalStore Γ}
     {s1 : Stm Γ τ} {s2 : Stm (ctx_snoc Γ (x, τ)) σ} {t : Stm Γ σ} (final : Final t)
-    (steps : ⟨ γ1, δ1, stm_let x τ s1 s2 ⟩ --->* ⟨ γ3, δ3, t ⟩) :
-    exists (γ2 : RegStore) (δ2 : LocalStore Γ) (s1' : Stm Γ τ),
-      ⟨ γ1, δ1, s1 ⟩ --->* ⟨ γ2, δ2, s1' ⟩ /\ Final s1' /\
+    (steps : ⟨ γ1, μ1, δ1, stm_let x τ s1 s2 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩) :
+    exists (γ2 : RegStore) (μ2 : Memory) (δ2 : LocalStore Γ) (s1' : Stm Γ τ),
+      ⟨ γ1, μ1, δ1, s1 ⟩ --->* ⟨ γ2, μ2, δ2, s1' ⟩ /\ Final s1' /\
       exists (s0 : Stm Γ σ),
-          ⟨ γ2, δ2, stm_let x τ s1' s2 ⟩ ---> ⟨ γ2, δ2, s0 ⟩ /\
-          ⟨ γ2, δ2, s0 ⟩ --->* ⟨ γ3, δ3, t ⟩.
+          ⟨ γ2, μ2, δ2, stm_let x τ s1' s2 ⟩ ---> ⟨ γ2, μ2, δ2, s0 ⟩ /\
+          ⟨ γ2, μ2, δ2, s0 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩.
   Proof.
     remember (stm_let x τ s1 s2) as s. revert steps s1 s2 Heqs.
     steps_inversion_induction.
   Qed.
 
-  Lemma steps_inversion_let' {Γ Δ σ} {γ1 γ3 : RegStore} {δ1 δ3 : LocalStore Γ}
+  Lemma steps_inversion_let' {Γ Δ σ} {γ1 γ3 : RegStore} {μ1 μ3 : Memory} {δ1 δ3 : LocalStore Γ}
     {δΔ : LocalStore Δ} {k : Stm (ctx_cat Γ Δ) σ} {t : Stm Γ σ} (final : Final t)
-    (steps : ⟨ γ1, δ1, stm_let' δΔ k ⟩ --->* ⟨ γ3, δ3, t ⟩) :
-    exists γ2 δ2 δΔ' k',
-      ⟨ γ1, env_cat δ1 δΔ , k ⟩ --->* ⟨ γ2, env_cat δ2 δΔ' , k' ⟩ /\ Final k' /\
+    (steps : ⟨ γ1, μ1, δ1, stm_let' δΔ k ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩) :
+    exists γ2 μ2 δ2 δΔ' k',
+      ⟨ γ1, μ1, env_cat δ1 δΔ , k ⟩ --->* ⟨ γ2, μ2, env_cat δ2 δΔ' , k' ⟩ /\ Final k' /\
       exists (s0 : Stm Γ σ),
-        ⟨ γ2, δ2, stm_let' δΔ' k' ⟩ ---> ⟨ γ2, δ2, s0 ⟩ /\
-        ⟨ γ2, δ2, s0 ⟩ --->* ⟨ γ3, δ3, t ⟩.
+        ⟨ γ2, μ2, δ2, stm_let' δΔ' k' ⟩ ---> ⟨ γ2, μ2, δ2, s0 ⟩ /\
+        ⟨ γ2, μ2, δ2, s0 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩.
   Proof.
     remember (stm_let' δΔ k) as s. revert steps δΔ k Heqs.
     steps_inversion_induction.
   Qed.
 
-  Lemma steps_inversion_seq {Γ τ σ} {γ1 γ3 : RegStore} {δ1 δ3 : LocalStore Γ}
+  Lemma steps_inversion_seq {Γ τ σ} {γ1 γ3 : RegStore} {μ1 μ3 : Memory} {δ1 δ3 : LocalStore Γ}
     (s1 : Stm Γ τ) (s2 : Stm Γ σ) (t : Stm Γ σ) (final : Final t)
-    (steps : ⟨ γ1, δ1, stm_seq s1 s2 ⟩ --->* ⟨ γ3, δ3, t ⟩) :
-    exists γ2 δ2 s1',
-      ⟨ γ1, δ1, s1 ⟩ --->* ⟨ γ2, δ2, s1' ⟩ /\ Final s1' /\
+    (steps : ⟨ γ1, μ1, δ1, stm_seq s1 s2 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩) :
+    exists γ2 μ2 δ2 s1',
+      ⟨ γ1, μ1, δ1, s1 ⟩ --->* ⟨ γ2, μ2, δ2, s1' ⟩ /\ Final s1' /\
       exists (s0 : Stm Γ σ),
-        ⟨ γ2, δ2, stm_seq s1' s2 ⟩ ---> ⟨ γ2, δ2 , s0 ⟩ /\
-        ⟨ γ2, δ2 , s0 ⟩ --->* ⟨ γ3, δ3, t ⟩.
+        ⟨ γ2, μ2, δ2, stm_seq s1' s2 ⟩ ---> ⟨ γ2, μ2, δ2 , s0 ⟩ /\
+        ⟨ γ2, μ2, δ2 , s0 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩.
   Proof.
     remember (stm_seq s1 s2) as s. revert steps s1 s2 Heqs.
     steps_inversion_induction.
   Qed.
 
-  Lemma steps_inversion_call' {Γ Δ σ} {γ1 γ3 : RegStore} {δ1 δ3 : LocalStore Γ}
+  Lemma steps_inversion_call' {Γ Δ σ} {γ1 γ3 : RegStore} {μ1 μ3 : Memory} {δ1 δ3 : LocalStore Γ}
     (δΔ : LocalStore Δ) (k : Stm Δ σ) (t : Stm Γ σ) (final : Final t)
-    (steps : ⟨ γ1, δ1, stm_call' Δ δΔ σ k ⟩ --->* ⟨ γ3, δ3, t ⟩) :
-    exists γ2 δΔ' k',
-      ⟨ γ1, δΔ , k ⟩ --->* ⟨ γ2, δΔ' , k' ⟩ /\ Final k' /\
+    (steps : ⟨ γ1, μ1, δ1, stm_call' Δ δΔ σ k ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩) :
+    exists μ2 γ2 δΔ' k',
+      ⟨ γ1, μ1, δΔ , k ⟩ --->* ⟨ γ2, μ2, δΔ' , k' ⟩ /\ Final k' /\
       exists s0,
-        ⟨ γ2, δ1, stm_call' Δ δΔ' σ k' ⟩ ---> ⟨ γ2, δ1, s0 ⟩ /\
-        ⟨ γ2, δ1, s0⟩ --->* ⟨ γ3, δ3, t ⟩.
+        ⟨ γ2, μ2, δ1, stm_call' Δ δΔ' σ k' ⟩ ---> ⟨ γ2, μ2, δ1, s0 ⟩ /\
+        ⟨ γ2, μ2, δ1, s0⟩ --->* ⟨ γ3, μ3, δ3, t ⟩.
   Proof.
     remember (stm_call' Δ δΔ σ k) as s. revert steps δΔ k Heqs.
     steps_inversion_induction.
   Qed.
 
-  Lemma steps_inversion_assign {Γ σ} {γ1 γ3 : RegStore} {δ1 δ3 : LocalStore Γ}
+  Lemma steps_inversion_assign {Γ σ} {γ1 γ3 : RegStore} {μ1 μ3 : Memory} {δ1 δ3 : LocalStore Γ}
     (x : 𝑿) (xInΓ : InCtx (x,σ) Γ) (s1 t : Stm Γ σ) (final : Final t)
-    (steps : ⟨ γ1, δ1, stm_assign x s1 ⟩ --->* ⟨ γ3, δ3, t ⟩) :
-    exists γ2 δ2 δ2' s1',
-      ⟨ γ1, δ1, s1 ⟩ --->* ⟨ γ2, δ2, s1' ⟩ /\ Final s1' /\
+    (steps : ⟨ γ1, μ1, δ1, stm_assign x s1 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩) :
+    exists γ2 μ2 δ2 δ2' s1',
+      ⟨ γ1, μ1, δ1, s1 ⟩ --->* ⟨ γ2, μ2, δ2, s1' ⟩ /\ Final s1' /\
       exists (s0 : Stm Γ σ),
-        ⟨ γ2, δ2, stm_assign x s1' ⟩ ---> ⟨ γ2, δ2' , s0 ⟩ /\
-        ⟨ γ2, δ2' , s0 ⟩ --->* ⟨ γ3, δ3, t ⟩.
+        ⟨ γ2, μ2, δ2, stm_assign x s1' ⟩ ---> ⟨ γ2, μ2, δ2' , s0 ⟩ /\
+        ⟨ γ2, μ2, δ2' , s0 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩.
   Proof.
     remember (stm_assign x s1) as s. revert steps x xInΓ s1 Heqs.
     steps_inversion_induction.
   Qed.
 
-  Lemma steps_inversion_bind {Γ τ σ} {γ1 γ3 : RegStore} {δ1 δ3 : LocalStore Γ}
+  Lemma steps_inversion_bind {Γ τ σ} {γ1 γ3 : RegStore} {μ1 μ3 : Memory} {δ1 δ3 : LocalStore Γ}
     (s1 : Stm Γ τ) (k : Lit τ -> Stm Γ σ) (t : Stm Γ σ) (final : Final t)
-    (steps : ⟨ γ1, δ1, stm_bind s1 k ⟩ --->* ⟨ γ3, δ3, t ⟩) :
-    exists γ2 δ2 s1',
-      ⟨ γ1, δ1, s1 ⟩ --->* ⟨ γ2, δ2, s1' ⟩ /\ Final s1' /\
+    (steps : ⟨ γ1, μ1, δ1, stm_bind s1 k ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩) :
+    exists γ2 μ2 δ2 s1',
+      ⟨ γ1, μ1, δ1, s1 ⟩ --->* ⟨ γ2, μ2, δ2, s1' ⟩ /\ Final s1' /\
       exists (s0 : Stm Γ σ),
-        ⟨ γ2, δ2, stm_bind s1' k ⟩ ---> ⟨ γ2, δ2 , s0 ⟩ /\
-        ⟨ γ2, δ2 , s0 ⟩ --->* ⟨ γ3, δ3, t ⟩.
+        ⟨ γ2, μ2, δ2, stm_bind s1' k ⟩ ---> ⟨ γ2, μ2, δ2 , s0 ⟩ /\
+        ⟨ γ2, μ2, δ2 , s0 ⟩ --->* ⟨ γ3, μ3, δ3, t ⟩.
   Proof.
     remember (stm_bind s1 k) as s. revert steps s1 k Heqs.
     steps_inversion_induction.

--- a/src/MicroSail/SmallStep/Progress.v
+++ b/src/MicroSail/SmallStep/Progress.v
@@ -75,15 +75,15 @@ Module Progress
 
   Local Ltac progress_inst T :=
     match goal with
-    | [ IH: (forall (γ : RegStore) (δ : LocalStore (ctx_cat ?Γ ?Δ)), _),
-        γ : RegStore, δ1: LocalStore ?Γ, δ2: LocalStore ?Δ |- _
-      ] => specialize (IH γ (env_cat δ1 δ2)); T
+    | [ IH: (forall (γ : RegStore) (μ : Memory) (δ : LocalStore (ctx_cat ?Γ ?Δ)), _),
+        γ : RegStore, μ : Memory, δ1: LocalStore ?Γ, δ2: LocalStore ?Δ |- _
+      ] => specialize (IH γ μ (env_cat δ1 δ2)); T
     (* | [ IH: (forall (δ : LocalStore (ctx_snoc ctx_nil (?x , ?σ))), _), *)
     (*     v: Lit ?σ |- _ *)
     (*   ] => specialize (IH (env_snoc env_nil x σ v)); T *)
-    | [ IH: (forall (γ : RegStore) (δ : LocalStore ?Γ), _),
+    | [ IH: (forall (γ : RegStore) (μ : Memory) (δ : LocalStore ?Γ), _),
         γ : RegStore, δ: LocalStore ?Γ |- _
-      ] => solve [ specialize (IH γ δ); T | clear IH; T ]
+      ] => solve [ specialize (IH γ μ δ); T | clear IH; T ]
     end.
 
   Local Ltac progress_tac :=
@@ -94,7 +94,7 @@ Module Progress
       ].
 
   Lemma progress {Γ σ} (s : Stm Γ σ) :
-    Final s \/ forall γ δ, exists γ' δ' s', ⟨ γ , δ , s ⟩ ---> ⟨ γ' , δ' , s' ⟩.
+    Final s \/ forall γ μ δ, exists γ' μ' δ' s', ⟨ γ , μ , δ , s ⟩ ---> ⟨ γ' , μ' , δ' , s' ⟩.
   Proof. induction s; intros; try progress_tac. Qed.
 
 End Progress.

--- a/src/MicroSail/SmallStep/Step.v
+++ b/src/MicroSail/SmallStep/Step.v
@@ -202,7 +202,7 @@ Module SmallStep
   | step_trans {γ2 γ3 : RegStore} {μ2 μ3 : Memory} {δ2 δ3 : LocalStore Γ} {s2 s3 : Stm Γ σ} :
       Step γ1 γ2 μ1 μ2 δ1 δ2 s1 s2 -> Steps γ2 μ2 δ2 s2 γ3 μ3 δ3 s3 -> Steps γ1 μ1 δ1 s1 γ3 μ3 δ3 s3.
 
-  Notation "⟨ γ1 , μ1 , δ1 , s1 ⟩ --->* ⟨ γ2 , μ2 , δ2 , s2 ⟩" := (@Steps _ _ γ1 δ1 s1 γ2 δ2 s2).
+  Notation "⟨ γ1 , μ1 , δ1 , s1 ⟩ --->* ⟨ γ2 , μ2 , δ2 , s2 ⟩" := (@Steps _ _ γ1 μ1 δ1 s1 γ2 μ2 δ2 s2).
 
   (* Tests if a statement is a final one, i.e. a finished computation. *)
   Ltac microsail_stm_is_final s :=

--- a/src/MicroSail/SmallStep/Step.v
+++ b/src/MicroSail/SmallStep/Step.v
@@ -43,158 +43,166 @@ Module SmallStep
   Import CtxNotations.
   Import EnvNotations.
 
-  Inductive Step {Γ : Ctx (𝑿 * Ty)} : forall {σ : Ty} (γ1 γ2 : RegStore) (δ1 δ2 : LocalStore Γ) (s1 s2 : Stm Γ σ), Prop :=
+  Inductive Step {Γ : Ctx (𝑿 * Ty)} : forall {σ : Ty} (γ1 γ2 : RegStore) (μ1 μ2 : Memory) (δ1 δ2 : LocalStore Γ) (s1 s2 : Stm Γ σ), Prop :=
 
   | step_stm_exp
-      (γ : RegStore) (δ : LocalStore Γ) (σ : Ty) (e : Exp Γ σ) :
-      ⟨ γ , δ , stm_exp e ⟩ ---> ⟨ γ , δ , stm_lit σ (eval e δ) ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (σ : Ty) (e : Exp Γ σ) :
+      ⟨ γ , μ , δ , (stm_exp e) ⟩ ---> ⟨ γ , μ , δ , stm_lit σ (eval e δ) ⟩
 
   | step_stm_let_value
-      (γ : RegStore) (δ : LocalStore Γ) (x : 𝑿) (τ σ : Ty) (v : Lit τ) (k : Stm (Γ ▻ (x , τ)) σ) :
-      ⟨ γ , δ , stm_let x τ (stm_lit τ v) k ⟩ ---> ⟨ γ , δ , stm_let' (env_snoc env_nil (x,τ) v) k ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (x : 𝑿) (τ σ : Ty) (v : Lit τ) (k : Stm (Γ ▻ (x , τ)) σ) :
+      ⟨ γ , μ , δ , stm_let x τ (stm_lit τ v) k ⟩ ---> ⟨ γ , μ , δ , stm_let' (env_snoc env_nil (x,τ) v) k ⟩
   | step_stm_let_fail
-      (γ : RegStore) (δ : LocalStore Γ) (x : 𝑿) (τ σ : Ty) (s : string) (k : Stm (Γ ▻ (x , τ)) σ) :
-      ⟨ γ , δ , stm_let x τ (stm_fail τ s) k ⟩ ---> ⟨ γ , δ , stm_fail σ s ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (x : 𝑿) (τ σ : Ty) (s : string) (k : Stm (Γ ▻ (x , τ)) σ) :
+      ⟨ γ , μ , δ, stm_let x τ (stm_fail τ s) k ⟩ ---> ⟨ γ , μ , δ , stm_fail σ s ⟩
   | step_stm_let_step
-      (γ γ' : RegStore) (δ δ' : LocalStore Γ) (x : 𝑿) (τ σ : Ty)
+      (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore Γ) (x : 𝑿) (τ σ : Ty)
       (s : Stm Γ τ) (s' : Stm Γ τ) (k : Stm (Γ ▻ (x , τ)) σ) :
-      ⟨ γ , δ , s ⟩ ---> ⟨ γ' , δ' , s' ⟩ ->
-      ⟨ γ , δ , stm_let x τ s k ⟩ ---> ⟨ γ', δ' , stm_let x τ s' k ⟩
+      ⟨ γ , μ , δ , s ⟩ ---> ⟨ γ' , μ' , δ' , s' ⟩ ->
+      ⟨ γ , μ , δ , stm_let x τ s k ⟩ ---> ⟨ γ', μ' , δ' , stm_let x τ s' k ⟩
   | step_stm_let'_value
-      (γ : RegStore) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) (δΔ : LocalStore Δ) (σ : Ty) (v : Lit σ) :
-      ⟨ γ , δ , stm_let' δΔ (stm_lit σ v) ⟩ ---> ⟨ γ , δ , stm_lit σ v ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) (δΔ : LocalStore Δ) (σ : Ty) (v : Lit σ) :
+      ⟨ γ , μ , δ , stm_let' δΔ (stm_lit σ v) ⟩ ---> ⟨ γ , μ , δ , stm_lit σ v ⟩
   | step_stm_let'_fail
-      (γ : RegStore) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) (δΔ : LocalStore Δ) (σ : Ty) (s : string) :
-      ⟨ γ , δ , stm_let' δΔ (stm_fail σ s) ⟩ ---> ⟨ γ , δ , stm_fail σ s ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) (δΔ : LocalStore Δ) (σ : Ty) (s : string) :
+      ⟨ γ , μ , δ , stm_let' δΔ (stm_fail σ s) ⟩ ---> ⟨ γ , μ , δ , stm_fail σ s ⟩
   | step_stm_let'_step
-      (γ γ' : RegStore) (δ δ' : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) (δΔ δΔ' : LocalStore Δ) (σ : Ty) (k k' : Stm (Γ ▻▻ Δ) σ) :
-      ⟨ γ , δ ►► δΔ , k ⟩ ---> ⟨ γ', δ' ►► δΔ' , k' ⟩ ->
-      ⟨ γ , δ , stm_let' δΔ k ⟩ ---> ⟨ γ' , δ' , stm_let' δΔ' k' ⟩
+      (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) (δΔ δΔ' : LocalStore Δ) (σ : Ty) (k k' : Stm (Γ ▻▻ Δ) σ) :
+      ⟨ γ , μ , δ ►► δΔ , k ⟩ ---> ⟨ γ', μ' , δ' ►► δΔ' , k' ⟩ ->
+      ⟨ γ , μ , δ , stm_let' δΔ k ⟩ ---> ⟨ γ' , μ' , δ' , stm_let' δΔ' k' ⟩
 
   | step_stm_seq_step
-      (γ γ' : RegStore) (δ δ' : LocalStore Γ) (τ σ : Ty) (s s' : Stm Γ τ) (k : Stm Γ σ) :
-      ⟨ γ , δ , s ⟩ ---> ⟨ γ' , δ' , s' ⟩ ->
-      ⟨ γ , δ , stm_seq s k ⟩ ---> ⟨ γ', δ' , stm_seq s' k ⟩
+      (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore Γ) (τ σ : Ty) (s s' : Stm Γ τ) (k : Stm Γ σ) :
+      ⟨ γ , μ , δ , s ⟩ ---> ⟨ γ' , μ' , δ' , s' ⟩ ->
+      ⟨ γ , μ , δ , stm_seq s k ⟩ ---> ⟨ γ' , μ' , δ' , stm_seq s' k ⟩
   | step_stm_seq_value
-      (γ : RegStore) (δ : LocalStore Γ) (τ σ : Ty) (v : Lit τ) (k : Stm Γ σ) :
-      ⟨ γ , δ , stm_seq (stm_lit τ v) k ⟩ ---> ⟨ γ , δ , k ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (τ σ : Ty) (v : Lit τ) (k : Stm Γ σ) :
+      ⟨ γ , μ , δ , stm_seq (stm_lit τ v) k ⟩ ---> ⟨ γ , μ , δ , k ⟩
   | step_stm_seq_fail
-      (γ : RegStore) (δ : LocalStore Γ) (τ σ : Ty) (s : string) (k : Stm Γ σ) :
-      ⟨ γ , δ , stm_seq (stm_fail τ s) k ⟩ ---> ⟨ γ , δ , stm_fail σ s ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (τ σ : Ty) (s : string) (k : Stm Γ σ) :
+      ⟨ γ , μ , δ , stm_seq (stm_fail τ s) k ⟩ ---> ⟨ γ , μ , δ , stm_fail σ s ⟩
 
   | step_stm_call
-      (γ : RegStore) (δ : LocalStore Γ) {σs σ} {f : 𝑭 σs σ} (es : Env' (Exp Γ) σs) :
-      ⟨ γ , δ , stm_call f es ⟩ --->
-      ⟨ γ , δ , stm_call' σs (evals es δ) σ (Pi f) ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σs σ} {f : 𝑭 σs σ} (es : Env' (Exp Γ) σs) :
+      ⟨ γ , μ , δ , stm_call f es ⟩ --->
+      ⟨ γ , μ , δ , stm_call' σs (evals es δ) σ (Pi f) ⟩
   | step_stm_call'_step
-      (γ γ' : RegStore) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) {δΔ δΔ' : LocalStore Δ} (τ : Ty)
+      (γ γ' : RegStore) (μ μ' : Memory) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) {δΔ δΔ' : LocalStore Δ} (τ : Ty)
       (s s' : Stm Δ τ) :
-      ⟨ γ , δΔ , s ⟩ ---> ⟨ γ' , δΔ' , s' ⟩ ->
-      ⟨ γ , δ , stm_call' Δ δΔ τ s ⟩ ---> ⟨ γ' , δ , stm_call' Δ δΔ' τ s' ⟩
+      ⟨ γ , μ , δΔ , s ⟩ ---> ⟨ γ' , μ' , δΔ' , s' ⟩ ->
+      ⟨ γ , μ , δ , stm_call' Δ δΔ τ s ⟩ ---> ⟨ γ' , μ' , δ , stm_call' Δ δΔ' τ s' ⟩
   | step_stm_call'_value
-      (γ : RegStore) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) {δΔ : LocalStore Δ} (τ : Ty) (v : Lit τ) :
-      ⟨ γ , δ , stm_call' Δ δΔ τ (stm_lit τ v) ⟩ ---> ⟨ γ , δ , stm_lit τ v ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) {δΔ : LocalStore Δ} (τ : Ty) (v : Lit τ) :
+      ⟨ γ , μ , δ , stm_call' Δ δΔ τ (stm_lit τ v) ⟩ ---> ⟨ γ , μ , δ , stm_lit τ v ⟩
   | step_stm_call'_fail
-      (γ : RegStore) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) {δΔ : LocalStore Δ} (τ : Ty) (s : string) :
-      ⟨ γ , δ , stm_call' Δ δΔ τ (stm_fail τ s) ⟩ ---> ⟨ γ , δ , stm_fail τ s ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (Δ : Ctx (𝑿 * Ty)) {δΔ : LocalStore Δ} (τ : Ty) (s : string) :
+      ⟨ γ , μ , δ , stm_call' Δ δΔ τ (stm_fail τ s) ⟩ ---> ⟨ γ , μ , δ , stm_fail τ s ⟩
 
   | step_stm_assign_value
-      (γ : RegStore) (δ : LocalStore Γ) (x : 𝑿) (σ : Ty) {xInΓ : InCtx (x , σ) Γ} (v : Lit σ) :
-      ⟨ γ , δ , stm_assign x (stm_lit σ v) ⟩ ---> ⟨ γ , δ ⟪ x ↦ v ⟫ , stm_lit σ v ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (x : 𝑿) (σ : Ty) {xInΓ : InCtx (x , σ) Γ} (v : Lit σ) :
+      ⟨ γ , μ , δ , stm_assign x (stm_lit σ v) ⟩ ---> ⟨ γ , μ , δ ⟪ x ↦ v ⟫ , stm_lit σ v ⟩
   | step_stm_assign_fail
-      (γ : RegStore) (δ : LocalStore Γ) (x : 𝑿) (σ : Ty) {xInΓ : InCtx (x , σ) Γ} (s : string) :
-      ⟨ γ , δ , stm_assign x (stm_fail σ s) ⟩ ---> ⟨ γ , δ , stm_fail σ s ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (x : 𝑿) (σ : Ty) {xInΓ : InCtx (x , σ) Γ} (s : string) :
+      ⟨ γ , μ , δ , stm_assign x (stm_fail σ s) ⟩ ---> ⟨ γ , μ , δ , stm_fail σ s ⟩
   | step_stm_assign_step
-      (γ γ' : RegStore) (δ δ' : LocalStore Γ) (x : 𝑿) (σ : Ty) {xInΓ : InCtx (x , σ) Γ} (s s' : Stm Γ σ) :
-      ⟨ γ , δ , s ⟩ ---> ⟨ γ' , δ' , s' ⟩ ->
-      ⟨ γ , δ , stm_assign x s ⟩ ---> ⟨ γ' , δ' , stm_assign x s' ⟩
+      (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore Γ) (x : 𝑿) (σ : Ty) {xInΓ : InCtx (x , σ) Γ} (s s' : Stm Γ σ) :
+      ⟨ γ , μ , δ , s ⟩ ---> ⟨ γ' , μ' , δ' , s' ⟩ ->
+      ⟨ γ , μ , δ , stm_assign x s ⟩ ---> ⟨ γ' , μ' , δ' , stm_assign x s' ⟩
 
   | step_stm_if
-      (γ : RegStore) (δ : LocalStore Γ) (e : Exp Γ ty_bool) (σ : Ty) (s1 s2 : Stm Γ σ) :
-      ⟨ γ , δ , stm_if e s1 s2 ⟩ ---> ⟨ γ , δ , if eval e δ then s1 else s2 ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (e : Exp Γ ty_bool) (σ : Ty) (s1 s2 : Stm Γ σ) :
+      ⟨ γ , μ , δ , stm_if e s1 s2 ⟩ ---> ⟨ γ , μ , δ , if eval e δ then s1 else s2 ⟩
   | step_stm_assert
-      (γ : RegStore) (δ : LocalStore Γ) (e1 : Exp Γ ty_bool) (e2 : Exp Γ ty_string) :
-      ⟨ γ , δ , stm_assert e1 e2 ⟩ --->
-      ⟨ γ , δ , if eval e1 δ then stm_lit ty_bool true else stm_fail ty_bool (eval e2 δ) ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (e1 : Exp Γ ty_bool) (e2 : Exp Γ ty_string) :
+      ⟨ γ , μ , δ , stm_assert e1 e2 ⟩ --->
+      ⟨ γ , μ , δ , if eval e1 δ then stm_lit ty_bool true else stm_fail ty_bool (eval e2 δ) ⟩
   | step_stm_match_list
-      (γ : RegStore) (δ : LocalStore Γ) {σ τ : Ty} (e : Exp Γ (ty_list σ)) (alt_nil : Stm Γ τ)
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σ τ : Ty} (e : Exp Γ (ty_list σ)) (alt_nil : Stm Γ τ)
       (xh xt : 𝑿) (alt_cons : Stm (Γ ▻ (xh , σ) ▻ (xt , ty_list σ)) τ) :
-      ⟨ γ , δ , stm_match_list e alt_nil xh xt alt_cons ⟩ --->
-      ⟨ γ , δ , match eval e δ with
+      ⟨ γ , μ , δ , stm_match_list e alt_nil xh xt alt_cons ⟩ --->
+      ⟨ γ , μ , δ , match eval e δ with
                 | nil => alt_nil
                 | cons vh vt => stm_let' (env_snoc (env_snoc env_nil (xh,σ) vh) (xt,ty_list σ) vt) alt_cons
                 end
       ⟩
   | step_stm_match_sum
-      (γ : RegStore) (δ : LocalStore Γ) {σinl σinr τ : Ty} (e : Exp Γ (ty_sum σinl σinr))
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σinl σinr τ : Ty} (e : Exp Γ (ty_sum σinl σinr))
       (xinl : 𝑿) (alt_inl : Stm (Γ ▻ (xinl , σinl)) τ)
       (xinr : 𝑿) (alt_inr : Stm (Γ ▻ (xinr , σinr)) τ) :
-      ⟨ γ , δ , stm_match_sum e xinl alt_inl xinr alt_inr ⟩ --->
-      ⟨ γ , δ , match eval e δ with
+      ⟨ γ , μ , δ , stm_match_sum e xinl alt_inl xinr alt_inr ⟩ --->
+      ⟨ γ , μ , δ , match eval e δ with
                 | inl v => stm_let' (env_snoc env_nil (xinl,σinl) v) alt_inl
                 | inr v => stm_let' (env_snoc env_nil (xinr,σinr) v) alt_inr
                 end
       ⟩
   | step_stm_match_pair
-      (γ : RegStore) (δ : LocalStore Γ) {σ1 σ2 τ : Ty} (e : Exp Γ (ty_prod σ1 σ2)) (xl xr : 𝑿)
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σ1 σ2 τ : Ty} (e : Exp Γ (ty_prod σ1 σ2)) (xl xr : 𝑿)
       (rhs : Stm (Γ ▻ (xl , σ1) ▻ (xr , σ2)) τ) :
-      ⟨ γ , δ , stm_match_pair e xl xr rhs ⟩ --->
-      ⟨ γ , δ , let (vl , vr) := eval e δ in
+      ⟨ γ , μ , δ , stm_match_pair e xl xr rhs ⟩ --->
+      ⟨ γ , μ , δ , let (vl , vr) := eval e δ in
                 stm_let' (env_snoc (env_snoc env_nil (xl,σ1) vl) (xr,σ2) vr) rhs
       ⟩
   | step_stm_match_enum
-      (γ : RegStore) (δ : LocalStore Γ) {E : 𝑬} (e : Exp Γ (ty_enum E)) {τ : Ty}
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {E : 𝑬} (e : Exp Γ (ty_enum E)) {τ : Ty}
       (alts : forall (K : 𝑬𝑲 E), Stm Γ τ) :
-      ⟨ γ , δ , stm_match_enum E e alts ⟩ ---> ⟨ γ , δ , alts (eval e δ) ⟩
+      ⟨ γ , μ , δ , stm_match_enum E e alts ⟩ ---> ⟨ γ , μ , δ , alts (eval e δ) ⟩
   | step_stm_match_tuple
-      (γ : RegStore) (δ : LocalStore Γ) {σs : Ctx Ty} {Δ : Ctx (𝑿 * Ty)}
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σs : Ctx Ty} {Δ : Ctx (𝑿 * Ty)}
       (e : Exp Γ (ty_tuple σs)) (p : TuplePat σs Δ)
       {τ : Ty} (rhs : Stm (ctx_cat Γ Δ) τ) :
-      ⟨ γ , δ , stm_match_tuple e p rhs ⟩ --->
-      ⟨ γ , δ , stm_let' (tuple_pattern_match p (eval e δ)) rhs ⟩
+      ⟨ γ , μ , δ , stm_match_tuple e p rhs ⟩ --->
+      ⟨ γ , μ , δ , stm_let' (tuple_pattern_match p (eval e δ)) rhs ⟩
 
   | step_stm_match_union
-      (γ : RegStore) (δ : LocalStore Γ) {U : 𝑼} (e : Exp Γ (ty_union U)) {τ : Ty}
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {U : 𝑼} (e : Exp Γ (ty_union U)) {τ : Ty}
       (altx : forall (K : 𝑼𝑲 U), 𝑿)
       (alts : forall (K : 𝑼𝑲 U), Stm (ctx_snoc Γ (altx K , 𝑼𝑲_Ty K)) τ) :
-      ⟨ γ , δ , stm_match_union U e altx alts ⟩ --->
-      ⟨ γ , δ , let (K , v) := eval e δ in
+      ⟨ γ , μ , δ , stm_match_union U e altx alts ⟩ --->
+      ⟨ γ , μ , δ , let (K , v) := eval e δ in
                 stm_let' (env_snoc env_nil (altx K, 𝑼𝑲_Ty K) (untag v)) (alts K)
       ⟩
   | step_stm_match_record
-      (γ : RegStore) (δ : LocalStore Γ) {R : 𝑹} {Δ : Ctx (𝑿 * Ty)}
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {R : 𝑹} {Δ : Ctx (𝑿 * Ty)}
       (e : Exp Γ (ty_record R)) (p : RecordPat (𝑹𝑭_Ty R) Δ)
       {τ : Ty} (rhs : Stm (ctx_cat Γ Δ) τ) :
-      ⟨ γ , δ , stm_match_record R e p rhs ⟩ --->
-      ⟨ γ , δ , stm_let' (record_pattern_match p (eval e δ)) rhs ⟩
+      ⟨ γ , μ , δ , stm_match_record R e p rhs ⟩ --->
+      ⟨ γ , μ , δ , stm_let' (record_pattern_match p (eval e δ)) rhs ⟩
 
-  | step_stm_reg_register
-      (γ : RegStore) (δ : LocalStore Γ) {σ : Ty} (r : 𝑹𝑬𝑮 σ) :
-      ⟨ γ, δ, stm_read_register r ⟩ ---> ⟨ γ, δ, stm_lit σ (read_register γ r) ⟩
+  | step_stm_read_register
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σ : Ty} (r : 𝑹𝑬𝑮 σ) :
+      ⟨ γ, μ , δ, stm_read_register r ⟩ ---> ⟨ γ, μ , δ, stm_lit σ (read_register γ r) ⟩
   | step_stm_write_register
-      (γ : RegStore) (δ : LocalStore Γ) {σ : Ty} (r : 𝑹𝑬𝑮 σ) (e : Exp Γ σ) :
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) {σ : Ty} (r : 𝑹𝑬𝑮 σ) (e : Exp Γ σ) :
       let v := eval e δ in
-      ⟨ γ, δ, stm_write_register r e ⟩ ---> ⟨ write_register γ r v , δ , stm_lit σ v ⟩
+      ⟨ γ , μ , δ, stm_write_register r e ⟩ ---> ⟨ write_register γ r v , μ , δ , stm_lit σ v ⟩
+
+  | step_stm_read_memory
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (addr : 𝑨𝑫𝑫𝑹) :
+      ⟨ γ, μ , δ, stm_read_memory addr ⟩ ---> ⟨ γ, μ , δ, stm_lit ty_int (read_memory μ addr) ⟩
+  | step_stm_write_memory
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (addr : 𝑨𝑫𝑫𝑹) (e : Exp Γ ty_int) :
+      let v := eval e δ in
+      ⟨ γ , μ , δ, stm_write_memory addr e ⟩ ---> ⟨ γ , write_memory μ addr v, δ , stm_lit ty_int v ⟩
 
   | step_stm_bind_step
-      (γ γ' : RegStore) (δ δ' : LocalStore Γ) (σ τ : Ty) (s s' : Stm Γ σ) (k : Lit σ -> Stm Γ τ) :
-      ⟨ γ , δ , s ⟩ ---> ⟨ γ', δ' , s' ⟩ ->
-      ⟨ γ , δ , stm_bind s k ⟩ ---> ⟨ γ', δ' , stm_bind s' k ⟩
+      (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore Γ) (σ τ : Ty) (s s' : Stm Γ σ) (k : Lit σ -> Stm Γ τ) :
+      ⟨ γ , μ , δ , s ⟩ ---> ⟨ γ', μ' , δ' , s' ⟩ ->
+      ⟨ γ , μ , δ , stm_bind s k ⟩ ---> ⟨ γ', μ' , δ' , stm_bind s' k ⟩
   | step_stm_bind_value
-      (γ : RegStore) (δ : LocalStore Γ) (σ τ : Ty) (v : Lit σ) (k : Lit σ -> Stm Γ τ) :
-      ⟨ γ , δ , stm_bind (stm_lit σ v) k ⟩ ---> ⟨ γ , δ , k v ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (σ τ : Ty) (v : Lit σ) (k : Lit σ -> Stm Γ τ) :
+      ⟨ γ , μ , δ , stm_bind (stm_lit σ v) k ⟩ ---> ⟨ γ , μ , δ , k v ⟩
   | step_stm_bind_fail
-      (γ : RegStore) (δ : LocalStore Γ) (σ τ : Ty) (s : string) (k : Lit σ -> Stm Γ τ) :
-      ⟨ γ , δ , stm_bind (stm_fail σ s) k ⟩ ---> ⟨ γ , δ , stm_fail τ s ⟩
+      (γ : RegStore) (μ : Memory) (δ : LocalStore Γ) (σ τ : Ty) (s : string) (k : Lit σ -> Stm Γ τ) :
+      ⟨ γ , μ , δ , stm_bind (stm_fail σ s) k ⟩ ---> ⟨ γ , μ , δ , stm_fail τ s ⟩
 
-  where "⟨ γ1 , δ1 , s1 ⟩ ---> ⟨ γ2 , δ2 , s2 ⟩" := (@Step _ _ γ1%env γ2%env δ1%env δ2%env s1%stm s2%stm).
+  where "⟨ γ1 , μ1 , δ1 , s1 ⟩ ---> ⟨ γ2 , μ2 , δ2 , s2 ⟩" := (@Step _ _ γ1%env γ2%env μ1%env μ2%env δ1%env δ2%env s1%stm s2%stm).
 
-  Inductive Steps {Γ : Ctx (𝑿 * Ty)} {σ : Ty} (γ1 : RegStore) (δ1 : LocalStore Γ) (s1 : Stm Γ σ) : RegStore -> LocalStore Γ -> Stm Γ σ -> Prop :=
-  | step_refl : Steps γ1 δ1 s1 γ1 δ1 s1
-  | step_trans {γ2 γ3 : RegStore} {δ2 δ3 : LocalStore Γ} {s2 s3 : Stm Γ σ} :
-      Step γ1 γ2 δ1 δ2 s1 s2 -> Steps γ2 δ2 s2 γ3 δ3 s3 -> Steps γ1 δ1 s1 γ3 δ3 s3.
+  Inductive Steps {Γ : Ctx (𝑿 * Ty)} {σ : Ty} (γ1 : RegStore) (μ1 : Memory) (δ1 : LocalStore Γ) (s1 : Stm Γ σ) : RegStore -> Memory -> LocalStore Γ -> Stm Γ σ -> Prop :=
+  | step_refl : Steps γ1 μ1 δ1 s1 γ1 μ1 δ1 s1
+  | step_trans {γ2 γ3 : RegStore} {μ2 μ3 : Memory} {δ2 δ3 : LocalStore Γ} {s2 s3 : Stm Γ σ} :
+      Step γ1 γ2 μ1 μ2 δ1 δ2 s1 s2 -> Steps γ2 μ2 δ2 s2 γ3 μ3 δ3 s3 -> Steps γ1 μ1 δ1 s1 γ3 μ3 δ3 s3.
 
-  Notation "⟨ γ1 , δ1 , s1 ⟩ --->* ⟨ γ2 , δ2 , s2 ⟩" := (@Steps _ _ γ1 δ1 s1 γ2 δ2 s2).
+  Notation "⟨ γ1 , μ1 , δ1 , s1 ⟩ --->* ⟨ γ2 , μ2 , δ2 , s2 ⟩" := (@Steps _ _ γ1 δ1 s1 γ2 δ2 s2).
 
   (* Tests if a statement is a final one, i.e. a finished computation. *)
   Ltac microsail_stm_is_final s :=
@@ -231,17 +239,19 @@ Module SmallStep
         | @stm_match_record   => idtac
         | @stm_read_register  => idtac
         | @stm_write_register => idtac
+        | @stm_read_memory    => idtac
+        | @stm_write_memory   => idtac
         end
       ].
 
   (* This 'Lemma' simply exists for testing that the above predicate on
      statements is complete with respect to the step relation. *)
-  Lemma microsail_stm_primitive_step__complete {Γ σ γ1 γ2 δ1 δ2} {s1 s2 : Stm Γ σ} :
-    ⟨ γ1 , δ1 , s1 ⟩ ---> ⟨ γ2 , δ2 , s2 ⟩ -> True.
+  Lemma microsail_stm_primitive_step__complete {Γ σ γ1 γ2 μ1 μ2 δ1 δ2} {s1 s2 : Stm Γ σ} :
+    ⟨ γ1 , μ1 , δ1 , s1 ⟩ ---> ⟨ γ2 , μ2 , δ2 , s2 ⟩ -> True.
     intro step. remember s1 as s1'.
     dependent destruction step;
       match goal with
-      | [ H: ⟨ _,_,_ ⟩ ---> ⟨ _,_,_ ⟩ |- _ ] =>
+      | [ H: ⟨ _,_,_,_ ⟩ ---> ⟨ _,_,_,_ ⟩ |- _ ] =>
         (* If there is a step hypothesis then this case represents a congruence
            rule, not an axiom rule. *)
         constructor

--- a/src/MicroSail/Syntax.v
+++ b/src/MicroSail/Syntax.v
@@ -798,6 +798,12 @@ Module Terms (typekit : TypeKit) (termkit : TermKit typekit).
      "'[hv' 'match:'  e  'in'  U  'with'  '/' |  alt1  x1  =>  rhs1  '/' |  alt2  x2  =>  rhs2  '/' 'end' ']'"
       ).
 
+  Notation "'match:' e 'in' '(' σ1 ',' σ2 ')' 'with' | '(' fst ',' snd ')' => rhs 'end'" :=
+    (@stm_match_pair _ σ1 σ2 _ e fst snd rhs)
+    (at level 100, fst pattern, snd pattern, format
+     "'[hv' 'match:' e 'in' '(' σ1 ',' σ2 ')' 'with' '/' | '(' fst ',' snd ')' => rhs '/' 'end' ']'"
+    ).
+
   Notation "'call' f a1 .. an" :=
     (stm_call f (env_snoc .. (env_snoc env_nil (_,_) a1) .. (_,_) an))
     (at level 10, f global, a1, an at level 9).

--- a/src/MicroSail/Syntax.v
+++ b/src/MicroSail/Syntax.v
@@ -258,7 +258,9 @@ Module Type TermKit (typekit : TypeKit).
 
   (* Names of registers. *)
   Parameter Inline 𝑹𝑬𝑮 : Ty -> Set.
-  (* Parameter Inline 𝑹𝑬𝑮_eq_dec : forall σ (r1 r2 : 𝑹𝑬𝑮 σ), {r1 = r2} + {r1 <> r2}. *)
+
+  (* Memory addresses. *)
+  Parameter Inline 𝑨𝑫𝑫𝑹 : Set.
 
 End TermKit.
 
@@ -590,6 +592,8 @@ Module Terms (typekit : TypeKit) (termkit : TermKit typekit).
       (p : RecordPat (𝑹𝑭_Ty R) Δ) {τ : Ty} (rhs : Stm (ctx_cat Γ Δ) τ) : Stm Γ τ
     | stm_read_register {τ} (reg : 𝑹𝑬𝑮 τ) : Stm Γ τ
     | stm_write_register {τ} (reg : 𝑹𝑬𝑮 τ) (e : Exp Γ τ) : Stm Γ τ
+    | stm_read_memory (addr : 𝑨𝑫𝑫𝑹) : Stm Γ ty_int
+    | stm_write_memory (addr : 𝑨𝑫𝑫𝑹) (e : Exp Γ ty_int) : Stm Γ ty_int
     | stm_bind   {σ τ : Ty} (s : Stm Γ σ) (k : Lit σ -> Stm Γ τ) : Stm Γ τ.
     Bind Scope stm_scope with Stm.
 
@@ -613,6 +617,8 @@ Module Terms (typekit : TypeKit) (termkit : TermKit typekit).
     Global Arguments stm_match_record {_} _ {_} _ _ {_} _.
     Global Arguments stm_read_register {_ _} _.
     Global Arguments stm_write_register {_ _} _ _.
+    Global Arguments stm_read_memory {_} _.
+    Global Arguments stm_write_memory {_} _ _.
 
   End Statements.
 
@@ -841,6 +847,12 @@ Module Type ProgramKit
 
   Parameter write_write : forall (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v1 v2 : Lit σ),
             write_register (write_register γ r v1) r v2 = write_register γ r v2.
+
+  (* Memory model *)
+  Parameter Memory : Type.
+  Bind Scope env_scope with Memory.
+  Parameter read_memory : forall (μ : Memory) (addr : 𝑨𝑫𝑫𝑹), Lit ty_int.
+  Parameter write_memory : forall (μ : Memory) (addr : 𝑨𝑫𝑫𝑹) (v : Lit ty_int), Memory.
 
   (* Parameter Inline Pi : forall {Δ τ} (f : 𝑭 Δ τ), FunDef Δ τ. *)
   Parameter Inline Pi : forall {Δ τ} (f : 𝑭 Δ τ), Stm Δ τ.

--- a/src/MicroSail/WLP/Dijkstra.v
+++ b/src/MicroSail/WLP/Dijkstra.v
@@ -89,6 +89,12 @@ Section WithGIL.
     fun k _ => k tt δ'.
   Definition modify_local {Γ Γ'} (f : L Γ -> L Γ') : DST G L Γ Γ' unit :=
     bind get_local (fun δ => put_local (f δ)).
+  Definition get_global {Γ} : DST G L Γ Γ G :=
+    fun k δ γ => k γ δ γ.
+  Definition put_global {Γ} (γ' : G) : DST G L Γ Γ unit :=
+    fun k δ γ' => k tt δ γ'.
+  Definition modify_global {Γ} (f : G -> G) : DST G L Γ Γ unit :=
+    bind get_global (fun γ => put_global (f γ)).
   Definition ifthenelse {Γ1 Γ2 A} (b : bool) (t e : DST G L Γ1 Γ2 A) : DST G L Γ1 Γ2 A :=
     fun k δ γ => (b = true -> t k δ γ) /\ (b = false -> e k δ γ).
 
@@ -98,11 +104,14 @@ Section WithGIL.
   Global Arguments bindleft {_ _ _ _ _} _ _ / _ _ _.
   Global Arguments bindright {_ _ _ _ _} _ _ / _ _ _.
   Global Arguments evalDST {_ _ _} _ / _ _ _.
+  Global Arguments get_global {_} / _ _ _.
   Global Arguments get_local {_} / _ _ _.
   Global Arguments lift_cont {_ _} _ / _ _ _.
   Global Arguments lift_cont_global {_ _} _ / _ _ _.
+  Global Arguments modify_global {_} _ / _ _ _.
   Global Arguments modify_local {_ _} _ / _ _ _.
   Global Arguments pure {_ _} _ / _ _ _.
+  Global Arguments put_global {_} _ / _ _ _.
   Global Arguments put_local {_ _} _ / _ _ _.
   Global Arguments ifthenelse {_ _ _} _ _ _ / _ _ _.
 

--- a/src/MicroSail/WLP/Soundness.v
+++ b/src/MicroSail/WLP/Soundness.v
@@ -77,9 +77,9 @@ Module Soundness
       match goal with
       | [ H: ResultNoFail _ _ |- _ ] =>
         apply result_no_fail_inversion in H; destruct_conjs; subst
-      | [ H: ⟨ _, _, ?s ⟩ ---> ⟨ _, _, _ ⟩ |- _ ] =>
+      | [ H: ⟨ _, _, _, ?s ⟩ ---> ⟨ _, _, _, _ ⟩ |- _ ] =>
         microsail_stm_primitive_step s; dependent destruction H
-      | [ H: ⟨ _, _, ?s ⟩ --->* ⟨ _, _, ?t ⟩, HF: Final ?t |- _ ] =>
+      | [ H: ⟨ _, _, _, ?s ⟩ --->* ⟨ _, _, _, ?t ⟩, HF: Final ?t |- _ ] =>
         first
           [ microsail_stm_primitive_step s; dependent destruction H; cbn in HF
           | match head s with
@@ -96,12 +96,12 @@ Module Soundness
 
   Local Ltac wlp_sound_inst :=
     match goal with
-    | [ IH: forall _ _ _ _ _, ⟨ _, _ , ?s ⟩ --->* ⟨ _, _ , _ ⟩ -> _,
-        HS: ⟨ _, _ , ?s ⟩ --->* ⟨ _, _ , ?t ⟩, HF: Final ?t |- _ ] =>
-      specialize (IH _ _ _ _ _ HS HF); clear HS HF
-    | [ IH: forall _ _ _ _ _ _, ⟨ _, _ , _ ⟩ --->* ⟨ _, _ , _ ⟩ -> _,
-        HS: ⟨ _, _ , _ ⟩ --->* ⟨ _, _ , ?t ⟩, HF: Final ?t |- _ ] =>
-      specialize (IH _ _ _ _ _ _ HS HF); clear HS HF
+    | [ IH: forall _ _ _ _ _ _ _, ⟨ _, _, _ , ?s ⟩ --->* ⟨ _, _, _ , _ ⟩ -> _,
+        HS: ⟨ _, _, _ , ?s ⟩ --->* ⟨ _, _, _ , ?t ⟩, HF: Final ?t |- _ ] =>
+      specialize (IH _ _ _ _ _ _ _ HS HF); clear HS HF
+    | [ IH: forall _ _ _ _ _ _ _ _, ⟨ _, _, _ , _ ⟩ --->* ⟨ _, _, _ , _ ⟩ -> _,
+        HS: ⟨ _, _, _ , _ ⟩ --->* ⟨ _, _, _ , ?t ⟩, HF: Final ?t |- _ ] =>
+      specialize (IH _ _ _ _ _ _ _ _ HS HF); clear HS HF
     | [ IH: forall POST, WLP ?s POST ?δ ?γ -> _, WP: WLP ?s _ ?δ ?γ |- _ ] =>
       specialize (IH _ WP); clear WP
     end.
@@ -132,8 +132,8 @@ Module Soundness
     forall σs σ (f : 𝑭 σs σ),
       match cenv σs σ f with
       | ContractNoFail _ _ pre post =>
-        forall (γ γ' : RegStore) (δ δ' : LocalStore σs) (s' : Stm σs σ),
-          ⟨ γ, δ, Pi f ⟩ --->* ⟨ γ', δ', s' ⟩ ->
+        forall (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore σs) (s' : Stm σs σ),
+          ⟨ γ, μ, δ, Pi f ⟩ --->* ⟨ γ', μ', δ', s' ⟩ ->
           Final s' ->
           uncurry pre δ γ ->
           ResultNoFail s' (fun v => uncurry post δ v γ')
@@ -181,7 +181,14 @@ Module Soundness
     - wlp_sound_solve.
     - wlp_sound_solve.
     - wlp_sound_solve.
+      change (eval e δ) with v in H2.
+      revert H2. generalize v. clear v. revert δ γ.
+      revert POST. clear.
+      admit.
     - wlp_sound_solve.
-  Qed.
+    - wlp_sound_solve.
+    - wlp_sound_solve.
+  Abort.
+  (* Qed. *)
 
 End Soundness.

--- a/src/MicroSail/WLP/Soundness.v
+++ b/src/MicroSail/WLP/Soundness.v
@@ -143,8 +143,8 @@ Module Soundness
       end.
 
   Lemma WLP_sound (validCEnv : ValidContractEnv CEnv) {Γ σ} (s : Stm Γ σ) :
-    forall (γ γ' : RegStore) (δ δ' : LocalStore Γ) (s' : Stm Γ σ),
-      ⟨ γ, δ, s ⟩ --->* ⟨ γ', δ', s' ⟩ -> Final s' ->
+    forall (γ γ' : RegStore) (μ μ' : Memory) (δ δ' : LocalStore Γ) (s' : Stm Γ σ),
+      ⟨ γ, μ, δ, s ⟩ --->* ⟨ γ', μ', δ', s' ⟩ -> Final s' ->
       forall (POST : Lit σ -> LocalStore Γ -> RegStore -> Prop),
         WLP s POST δ γ -> ResultNoFail s' (fun v => POST v δ' γ').
   Proof.

--- a/src/MicroSail/WLP/Spec.v
+++ b/src/MicroSail/WLP/Spec.v
@@ -148,8 +148,11 @@ Module WLP
     | stm_match_record R e p rhs =>
       meval e >>= fun v =>
       pushs (record_pattern_match p v) *> WLP _ _ rhs <* pops _
-    | stm_read_register r => abort
-    | stm_write_register r e => abort
+    | stm_read_register r => get_global >>= (fun γ => pure (read_register γ r))
+    | stm_write_register r e => meval e >>=
+        (fun v => modify_global (fun γ => write_register γ r v) *> pure v)
+    | stm_read_memory r => abort
+    | stm_write_memory r e => abort
     | stm_bind s k =>
       WLP _ _ s >>= fun v => WLP _ _ (k v)
     end) in exact body.

--- a/test/Example.v
+++ b/test/Example.v
@@ -155,6 +155,8 @@ Module ExampleTermKit <: (TermKit ExampleTypeKit).
 
   Definition 𝑹𝑬𝑮 : Ty -> Set := fun _ => Empty_set.
 
+  Definition 𝑨𝑫𝑫𝑹 : Set := Empty_set.
+
 End ExampleTermKit.
 Module ExampleTerms := Terms ExampleTypeKit ExampleTermKit.
 Import ExampleTerms.
@@ -204,19 +206,34 @@ Module ExampleProgramKit <: (ProgramKit ExampleTypeKit ExampleTermKit).
     end in exact pi.
   Defined.
 
-Definition RegStore := Empty_set.
+Definition RegStore : Set := Empty_set.
+
 Definition read_register (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) : Lit σ :=
   match r with end.
+
 Definition write_register (γ : RegStore) {σ} (r : 𝑹𝑬𝑮 σ) (v : Lit σ) : RegStore :=
   match r with end.
+
 Definition read_write (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v : Lit σ) :
     read_register (write_register γ r v) r = v := match r with end.
+
 Definition write_read (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) :
     (write_register γ r (read_register γ r)) = γ := match r with end.
+
 Definition write_write (γ : RegStore) σ (r : 𝑹𝑬𝑮 σ) (v1 v2 : Lit σ) :
     write_register (write_register γ r v1) r v2 = write_register γ r v2 :=
   match r with end.
+
+Definition Memory : Set := Empty_set.
+
+Definition read_memory (μ : Memory) (addr : 𝑨𝑫𝑫𝑹) : Lit ty_int :=
+  match addr with end.
+
+Definition write_memory (μ : Memory) (addr : 𝑨𝑫𝑫𝑹) (v : Lit ty_int) : Memory :=
+  match addr with end.
+
 End ExampleProgramKit.
+
 Module ExamplePrograms :=
   Programs ExampleTypeKit ExampleTermKit ExampleProgramKit.
 Import ExamplePrograms.


### PR DESCRIPTION
This a bit of a cluttered PR, but the main highlights are the following:

* The small-step semantics is extended with two memory-related statements, namely `stm_read_memory` and `stm_write_memory`. This extension introduces the need to update the statements of lemmas/theorems/WLP with memory variables.
* Work on the ISA example
* Bonus: notation for pattern-matching on pairs.